### PR TITLE
Fix typo in license text

### DIFF
--- a/0 -License.txt
+++ b/0 -License.txt
@@ -49,7 +49,7 @@ The following database is under the copyright (c) of MySQL
 
 -------------------------------------------------------------------------------------------------------------
 
-The sample data used in the the following database is Copyright Statistics Finland, 
+The sample data used in the following database is Copyright Statistics Finland, 
 http://www.stat.fi/worldinfigures. 
 -------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- fix typo in `0 -License.txt`

## Testing
- `grep -n "the the" -n '0 -License.txt'`

------
https://chatgpt.com/codex/tasks/task_e_68457bdfa5f48325ad1314af209ef2d9